### PR TITLE
Added Animation Looping and Animation Naming

### DIFF
--- a/Include/Animation.cc
+++ b/Include/Animation.cc
@@ -32,17 +32,30 @@ uint Fluidity::Keyframe::InterpolateYTo(int End, float ElapsedTime) {
 
 Fluidity::Animation::Animation() { TickInterval = 0; }
 
-Fluidity::Animation::Animation(uint16_t TickRate) { TickInterval = 1000/TickRate; }
+Fluidity::Animation::Animation(std::string _Name, uint16_t TickRate) { Name = _Name; TickInterval = 1000/TickRate; }
 
+
+std::string Fluidity::Animation::GetName() {
+    return Name;
+}
 
 uint Fluidity::Animation::GetTickInterval() {
     return TickInterval;
+}
+
+bool Fluidity::Animation::GetLooping() {
+    return Looping;
 }
 
 int Fluidity::Animation::CountKeyframes() {
     return Keyframes.size();
 }
 
+
+Fluidity::Animation* Fluidity::Animation::SetLooping(bool _Looping) {
+    Looping = _Looping;
+    return this;
+}
 
 Fluidity::Animation* Fluidity::Animation::AddKeyframe(uint X, uint Y, uint Duration, uint(*InterpolationFunction)(int, int, float)) {
     if (Keyframes.size() == 50) std::__throw_length_error("Fluidity::Animation::AddKeyframe(uint)");

--- a/Include/FluidWindow.cc
+++ b/Include/FluidWindow.cc
@@ -14,11 +14,18 @@ bool Fluidity::FluidWindow::OnAnimationTick() {
     if (TimeFrozen == true) return true;
 
     if (TimeScale > 0 ? (KeyframeIndex == CurrentAnimation.CountKeyframes() - 1) : (KeyframeIndex == 0)) {
-        // Mark Current Animation as Completed
-        ElapsedTime = KeyframeIndex = 0;
-        CurrentAnimation = Animation();
+        // Call the callback function when the current animation is completed
+        OnAnimationCompleted();
 
-        // Stop the ticks
+        // Mark Current Animation as Completed
+        ElapsedTime = 0;
+        KeyframeIndex = (CurrentAnimation.CountKeyframes() - 1) * (TimeScale < 0);
+        
+        // Continue the ticks if the current animation is loop
+        if (CurrentAnimation.GetLooping()) return true;
+
+        // Reset the current animation and stop the ticks if it is not looping
+        CurrentAnimation = Animation();
         return false;
     }
 
@@ -46,8 +53,8 @@ bool Fluidity::FluidWindow::OnAnimationTick() {
 }
 
 
-Fluidity::Animation Fluidity::FluidWindow::GetCurrentAnimation() {
-    return CurrentAnimation;
+Fluidity::Animation* Fluidity::FluidWindow::GetCurrentAnimation() {
+    return &CurrentAnimation;
 }
 
 size_t Fluidity::FluidWindow::GetCurrentKeyframeIndex() {

--- a/Include/Fluidity.h
+++ b/Include/Fluidity.h
@@ -23,16 +23,21 @@ namespace Fluidity {
 
     class Animation {
         private:
+            std::string Name;
             uint TickInterval;
+            bool Looping;
             std::vector<Keyframe> Keyframes;
 
         public:
             Animation();
-            Animation(uint16_t TickRate);
+            Animation(std::string _Name, uint16_t TickRate);
 
+            std::string GetName();
             uint GetTickInterval();
+            bool GetLooping();
             int CountKeyframes();
 
+            Animation* SetLooping(bool _Looping);
             Animation* AddKeyframe(uint X, uint Y, uint Duration, uint(*InterpolationFunction)(int, int, float));
 
             Keyframe operator[](int i);
@@ -63,11 +68,12 @@ namespace Fluidity {
             bool OnAnimationTick();
 
         protected:
-            Animation GetCurrentAnimation();
+            Animation* GetCurrentAnimation();
             size_t GetCurrentKeyframeIndex();
 
-            virtual void Start() {};
-            virtual void OnFrameStarted() {};
+            virtual void Start() {}
+            virtual void OnFrameStarted() {}
+            virtual void OnAnimationCompleted() {}
 
         public:
             FluidWindow();

--- a/Source/Entry.cpp
+++ b/Source/Entry.cpp
@@ -3,27 +3,25 @@
 
 class TestWindow : public Fluidity::FluidWindow {
     private:
+        int LoopCounter;
         int FrameCounter;
 
     protected:
         void Start() {
-            FrameCounter = 0;
+            LoopCounter = FrameCounter = 0;
             set_default_size(200, 200);
         }
 
         void OnFrameStarted() {
             FrameCounter++;
-            if (FrameCounter == 60) {
-                std::cout << "reverse!\n";
-                SetTimeScale(-1);
-            }
-            if (FrameCounter == 85) {
-                std::cout << "freeze!\n";
-                SetTimeScale(0);
-            }
-            if (FrameCounter == 115) {
-                std::cout << "reverse!\n";
-                SetTimeScale(1);
+            if (FrameCounter == 65) SetTimeScale(-1);
+        }
+
+        void OnAnimationCompleted() {
+            std::cout << GetCurrentAnimation()->GetName() << "\n";
+            LoopCounter++;
+            if (LoopCounter == 5) {
+                GetCurrentAnimation()->SetLooping(false);
             }
         }
 };
@@ -32,11 +30,12 @@ int main(int argc, char *argv[]) {
     auto App = Gtk::Application::create(argc, argv, "ex.angd.FluidityTest");
 
     TestWindow window;
-    Fluidity::Animation animation(60);
+    Fluidity::Animation animation("ExampleAnimation", 60);
     animation.AddKeyframe(0, 0, 1, Fluidity::Interpolation::Null)
             ->AddKeyframe(0, 0, 20, Fluidity::Interpolation::Null)
             ->AddKeyframe(1166, 568, 30, Fluidity::Interpolation::SmootherStep)
-            ->AddKeyframe(1166, 0, 20, Fluidity::Interpolation::SmootherStep);
+            ->AddKeyframe(1166, 0, 20, Fluidity::Interpolation::SmootherStep)
+            ->SetLooping(true);
     window.PlayAnimation(animation);
 
     return App->run(window);


### PR DESCRIPTION
Added the ability to loop animations
The "Fluidity::Animation::Looping" boolean is used for marking an animation for looping.

Looping can be enabled or disabled using the "Fluidity::Animation::SetLooping(bool)" function.
The current value of the boolean can also be retrieved using the "bool Fluidity::Animation::GetLooping()" function.

A new callback "Fluidity::Animation::OnAnimationCompleted()" has also been added.
As the name suggests, this new callback is called every time an animation is completed. If it is looping, it is called every time a loop is completed.

Also added the ability to name animations
The "Fluidity::Animation::Name" string holds the name for the animation

The name of an animation can only be set with a constructor and there is no function to change it after initialization.
The name of the animation can be retrieved using the "std::string Fluidity::Animation::GetName()" function.