### PR TITLE
Added Animation Queuing

### DIFF
--- a/Include/Animation.cc
+++ b/Include/Animation.cc
@@ -43,7 +43,11 @@ uint Fluidity::Animation::GetTickInterval() {
     return TickInterval;
 }
 
-bool Fluidity::Animation::GetLooping() {
+bool Fluidity::Animation::IsNamed(std::string _Name) {
+    return Name == _Name;
+}
+
+bool Fluidity::Animation::IsLooping() {
     return Looping;
 }
 

--- a/Include/Fluidity.h
+++ b/Include/Fluidity.h
@@ -3,6 +3,7 @@
 
 #include <gtkmm-3.0/gtkmm.h>
 #include <vector>
+#include <queue>
 
 namespace Fluidity {
     // Animation.cc
@@ -34,7 +35,8 @@ namespace Fluidity {
 
             std::string GetName();
             uint GetTickInterval();
-            bool GetLooping();
+            bool IsNamed(std::string _Name);
+            bool IsLooping();
             int CountKeyframes();
 
             Animation* SetLooping(bool _Looping);
@@ -59,7 +61,9 @@ namespace Fluidity {
 
     class FluidWindow : public Gtk::Window {
         private:
+            bool Playing;
             Animation CurrentAnimation;
+            std::queue<Animation> AnimationQueue;
             size_t KeyframeIndex;
             float ElapsedTime;
             bool TimeFrozen;
@@ -78,6 +82,7 @@ namespace Fluidity {
         public:
             FluidWindow();
 
+            bool IsPlaying();
             int GetTimeScale();
 
             void PlayAnimation(Animation _Animation);

--- a/Source/Entry.cpp
+++ b/Source/Entry.cpp
@@ -18,9 +18,8 @@ class TestWindow : public Fluidity::FluidWindow {
         }
 
         void OnAnimationCompleted() {
-            std::cout << GetCurrentAnimation()->GetName() << "\n";
             LoopCounter++;
-            if (LoopCounter == 5) {
+            if (GetCurrentAnimation()->IsNamed("ExampleAnimation") && LoopCounter == 5) {
                 GetCurrentAnimation()->SetLooping(false);
             }
         }
@@ -37,6 +36,18 @@ int main(int argc, char *argv[]) {
             ->AddKeyframe(1166, 0, 20, Fluidity::Interpolation::SmootherStep)
             ->SetLooping(true);
     window.PlayAnimation(animation);
+    Fluidity::Animation animation2("ExampleAnimation2", 60);
+    animation2.AddKeyframe(500, 500, 1, Fluidity::Interpolation::Null)
+            ->AddKeyframe(500, 500, 20, Fluidity::Interpolation::Null)
+            ->AddKeyframe(0, 0, 30, Fluidity::Interpolation::SmootherStep)
+            ->AddKeyframe(800, 200, 20, Fluidity::Interpolation::SmootherStep);
+    window.PlayAnimation(animation2);
+    Fluidity::Animation animation3("ExampleAnimation3", 60);
+    animation3.AddKeyframe(200, 200, 1, Fluidity::Interpolation::Null)
+            ->AddKeyframe(200, 200, 20, Fluidity::Interpolation::Null)
+            ->AddKeyframe(1166, 568, 30, Fluidity::Interpolation::SmootherStep)
+            ->AddKeyframe(1166, 0, 20, Fluidity::Interpolation::SmootherStep);
+    window.PlayAnimation(animation3);
 
     return App->run(window);
 }


### PR DESCRIPTION
# Changelog

## "PlayAnimation()" Behavioral Changes
- The `Fluidity::FluidWindow::PlayAnimation(Fluidity::Animation)` function will now queue an animation if an animation is currently being played. The queued animation will be played after the current animation has finished.
If the current animation is looping, the function will wait till it stops.

- The current animation is no longer reset after it is finished, instead a new `Fluidity::FluidWindow::Playing` boolean has been added. (See next section)

## "Playing" Boolean and "IsPlaying()" Function
- This new boolean cannot be modified by external objects, it can only be retrieved using the `bool Fluidity::FluidWindow::IsPlaying()` function.

## "IsNamed()" Function
- A new `bool Fluidity::Animation::IsNamed(std::string)` function has been added for better convenience which, as the name suggests, returns true if the provided string is equal to the name of the animation it is called for.

## "GetLooping()" Function renamed to "IsLooping()"
- The `bool Fluidity::Animation::GetLooping()` function has been renamed to `bool Fluidity::Animation::IsLooping()`.